### PR TITLE
Added CORS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ hyper-native-tls = "0.2.2"
 conduit-mime-types = "0.7.3"
 # Iron crates
 iron = "^0.5.0"
+iron-cors = "^0.5.0"
 multipart = { version="0.12.0", features=["iron"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,7 +188,7 @@ fn main() {
     let range = !matches.is_present("norange");
     let cert = matches.value_of("cert");
     let certpass = matches.value_of("certpass");
-    let cors = matches.occurrences_of("cors") != 0;
+    let cors = matches.is_present("cors");
     let ip = matches.value_of("ip").unwrap();
     let port = matches
         .value_of("port")
@@ -236,7 +236,7 @@ Address: {}
             enable_string(index),
             enable_string(upload),
             enable_string(cache),
-            (if cors { "enabled" } else { "disabled" }).to_string(),
+            enable_string(cors),
             enable_string(range),
             enable_string(sort),
             threads.to_string(),


### PR DESCRIPTION
Added "--cors" - Enable CORS via the Access-Control-Allow-Origin header. Inspired by the same flag of node's "https-server".