### PR TITLE
Added silent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 <img src="./screenshot.png" width="80%" height="80%">
 
 ### Command Line Arguments
-
 ```
 Simple HTTP(s) Server 0.4.5
 
@@ -18,6 +17,7 @@ FLAGS:
         --nocache    Disable http cache
         --norange    Disable header::Range support (partial request)
         --nosort     Disable directory entries sort (by: name, modified, size)
+    -s, --silent     Disable all outputs
     -u, --upload     Enable upload files (multiple select)
     -V, --version    Prints version information
 
@@ -81,3 +81,4 @@ simple-http-server -h
 - [x] HTTPS support
 - [x] Content-Encoding: gzip/deflate
 - [x] Added CORS headers support
+- [x] Silent mode

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,6 +192,11 @@ fn main() {
                  }
              })
              .help("serve this file (server root relative) in place of missing files (useful for single page apps)"))
+        .arg(clap::Arg::with_name("silent")
+             .long("silent")
+             .short("s")
+             .takes_value(false)
+             .help("Disable all outputs"))
         .get_matches();
 
     let root = matches
@@ -234,35 +239,39 @@ fn main() {
     } else {
         format!("{:?}", compression_exts)
     };
-    printer.println_out(
-        r#"     Index: {}, Upload: {}, Cache: {}, Cors: {}, Range: {}, Sort: {}, Threads: {}
-      Auth: {}, Compression: {}
-     https: {}, Cert: {}, Cert-Password: {}
-      Root: {},
-TryFile404: {}
-   Address: {}
-======== [{}] ========"#,
-        &vec![
-            enable_string(index),
-            enable_string(upload),
-            enable_string(cache),
-            enable_string(cors),
-            enable_string(range),
-            enable_string(sort),
-            threads.to_string(),
-            auth.unwrap_or("disabled").to_string(),
-            compression_string,
-            (if cert.is_some() { "enabled" } else { "disabled" }).to_string(),
-            cert.unwrap_or("").to_owned(),
-            certpass.unwrap_or("").to_owned(),
-            root.to_str().unwrap().to_owned(),
-            try_file_404.unwrap_or("").to_owned(),
-            format!("{}://{}", if cert.is_some() {"https"} else {"http"}, addr),
-            now_string()
-        ].iter()
-            .map(|s| (s.as_str(), &color_blue))
-            .collect::<Vec<(&str, &Option<ColorSpec>)>>()
-    ).unwrap();
+    let silent = matches.is_present("silent");
+
+    if ! silent {
+        printer.println_out(
+            r#"     Index: {}, Upload: {}, Cache: {}, Cors: {}, Range: {}, Sort: {}, Threads: {}
+          Auth: {}, Compression: {}
+         https: {}, Cert: {}, Cert-Password: {}
+          Root: {},
+    TryFile404: {}
+       Address: {}
+    ======== [{}] ========"#,
+            &vec![
+                enable_string(index),
+                enable_string(upload),
+                enable_string(cache),
+                enable_string(cors),
+                enable_string(range),
+                enable_string(sort),
+                threads.to_string(),
+                auth.unwrap_or("disabled").to_string(),
+                compression_string,
+                (if cert.is_some() { "enabled" } else { "disabled" }).to_string(),
+                cert.unwrap_or("").to_owned(),
+                certpass.unwrap_or("").to_owned(),
+                root.to_str().unwrap().to_owned(),
+                try_file_404.unwrap_or("").to_owned(),
+                format!("{}://{}", if cert.is_some() {"https"} else {"http"}, addr),
+                now_string()
+            ].iter()
+                .map(|s| (s.as_str(), &color_blue))
+                .collect::<Vec<(&str, &Option<ColorSpec>)>>()
+        ).unwrap();
+    }
 
     let mut chain = Chain::new(MainHandler{
         root, index, upload, cache, range, sort,
@@ -285,7 +294,9 @@ TryFile404: {}
             chain.link_after(CompressionHandler);
         }
     }
-    chain.link_after(RequestLogger{ printer: Printer::new() });
+    if ! silent {
+        chain.link_after(RequestLogger{ printer: Printer::new() });
+    }
     let mut server = Iron::new(chain);
     server.threads = threads as usize;
     let rv = if let Some(cert) = cert {


### PR DESCRIPTION
Hi!

Thanks for this nice server ! I used to use node's [http-server](https://www.npmjs.com/package/http-server) but I wasn't really satisfied with it. However, it has a `silent` option, that disables all outputs.

This pull requests adds this feature. I didn't disable the error message, because I think it would not be user friendly if the program failed silently.