### PR TITLE
HTML escape filenames

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ conduit-mime-types = "0.7.3"
 iron = "^0.5.0"
 iron-cors = "^0.5.0"
 multipart = { version="0.12.0", features=["iron"] }
+htmlescape = "0.3.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ extern crate iron_cors;
 extern crate multipart;
 extern crate hyper_native_tls;
 extern crate conduit_mime_types as mime_types;
+extern crate htmlescape;
 
 mod util;
 mod color;
@@ -40,6 +41,7 @@ use multipart::server::{Multipart, SaveResult};
 use pretty_bytes::converter::convert;
 use termcolor::{Color, ColorSpec};
 use url::percent_encoding::{percent_decode};
+use htmlescape::encode_minimal;
 
 use util::{
     ROOT_LINK,
@@ -443,7 +445,8 @@ impl MainHandler {
             while !breadcrumb.is_empty() {
                 bread_links.push(format!(
                     r#"<a href="/{link}/"><strong>{label}</strong></a>"#,
-                    link=encode_link_path(&breadcrumb), label=breadcrumb.pop().unwrap().to_owned(),
+                    link=encode_link_path(&breadcrumb),
+                    label=encode_minimal(&breadcrumb.pop().unwrap().to_owned()),
                 ));
             }
             bread_links.push(ROOT_LINK.to_owned());
@@ -596,7 +599,7 @@ impl MainHandler {
 "#,
                 linkstyle=link_style,
                 link=encode_link_path(&link),
-                label=file_name_label,
+                label=encode_minimal(&file_name_label),
                 modified=file_modified,
                 filesize=file_size
             ));


### PR DESCRIPTION
This PR resolves #15.

Like @Flakebi, I also happen to have a file called `<svg onload=alert(1)>`, which was causing some client-side difficulties :) I outsourced the html escaping logic to the htmlescape library. I aimed to escape all the `{label}` format strings, since those appeared to be the only cases where file/dir names where displayed in the page. Chrome did a decent job of preventing XSS behavior, so I couldn't actually get the breadcrumbs to show a malicious filename, but I escaped it anyway.