### PR TITLE
Make TLS support optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ flate2 = "1.0.11"
 filetime = "0.2.7"
 pretty-bytes = "0.2.2"
 url = "2.1.0"
-hyper-native-tls = "0.3.0"
+hyper-native-tls = {version = "0.3.0", optional=true}
 mime_guess = "2.0"
 # Iron crates
 iron = "0.6.1"
@@ -28,3 +28,7 @@ multipart = { version = "0.16.1", features = ["iron"] }
 htmlescape = "0.3.1"
 percent-encoding = "2.1.0"
 path-dedot = "1"
+
+[features]
+default = ["tls"]
+tls = ["hyper-native-tls"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,6 +328,8 @@ fn main() {
     }
     let mut server = Iron::new(chain);
     server.threads = threads as usize;
+
+    #[cfg(feature = "tls")]
     let rv = if let Some(cert) = cert {
         use hyper_native_tls::NativeTlsServer;
         let ssl = NativeTlsServer::new(cert, certpass.unwrap_or("")).unwrap();
@@ -335,6 +337,19 @@ fn main() {
     } else {
         server.http(&addr)
     };
+    #[cfg(not(feature = "tls"))]
+    let rv = if cert.is_some() {
+        printer
+            .println_err(
+                "{}: TLS support is not enabled during compilation of simple-http-server",
+                &[("ERROR", &Some(build_spec(Some(Color::Red), true)))],
+            )
+            .unwrap();
+        std::process::exit(1)
+    } else {
+        server.http(&addr)
+    };
+
     if let Err(e) = rv {
         printer
             .println_err(


### PR DESCRIPTION
Enable easy cross-compilation of simple-http-server for environment where TLS is not needed.