### PR TITLE
Add option --baseurl to allow running behind a reverse proxy

### DIFF
--- a/src/middlewares/logger.rs
+++ b/src/middlewares/logger.rs
@@ -17,6 +17,7 @@ lazy_static! {
 
 pub struct RequestLogger {
     pub printer: Printer,
+    pub base_url: String,
 }
 
 impl RequestLogger {
@@ -68,6 +69,7 @@ impl AfterMiddleware for RequestLogger {
             Ok(error_resp(
                 err.response.status.unwrap_or(status::InternalServerError),
                 err.error.to_string().as_str(),
+                &self.base_url,
             ))
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,7 +21,12 @@ const FRAGMENT_ENCODE_SET: &AsciiSet = &percent_encoding::CONTROLS
 const PATH_ENCODE_SET: &AsciiSet = &FRAGMENT_ENCODE_SET.add(b'#').add(b'?').add(b'{').add(b'}');
 const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &PATH_ENCODE_SET.add(b'/').add(b'%').add(b'[').add(b']');
 
-pub const ROOT_LINK: &str = r#"<a href="/"><strong>[Root]</strong></a>"#;
+pub fn root_link(baseurl: &str) -> String {
+    format!(
+        r#"<a href="{baseurl}"><strong>[Root]</strong></a>"#,
+        baseurl = baseurl,
+    )
+}
 
 #[derive(Debug)]
 pub struct StringError(pub String);
@@ -136,7 +141,7 @@ pub fn system_time_to_date_time(t: SystemTime) -> DateTime<Local> {
     Local.timestamp_opt(sec, nsec).unwrap()
 }
 
-pub fn error_resp(s: status::Status, msg: &str) -> Response {
+pub fn error_resp(s: status::Status, msg: &str, baseurl: &str) -> Response {
     let mut resp = Response::with((
         s,
         format!(
@@ -152,7 +157,7 @@ pub fn error_resp(s: status::Status, msg: &str) -> Response {
 </body>
 </html>
 "#,
-            root_link = ROOT_LINK,
+            root_link = root_link(baseurl),
             code = s.to_u16(),
             msg = msg
         ),


### PR DESCRIPTION
Overriding base URL from `/` to other value modifies all links in directory listings to begin from custom location instead of just `/`.

This allows using simple-http-server behind a reverse proxy that maps only request from a website's "subdirectory" to simple-http-server.

Example nginx config snippet:

```
location /filemanager/ {
    rewrite /filemanager/(.*) /$1 break;
    proxy_pass http://127.0.0.1:7682/;
    proxy_request_buffering off;
    proxy_buffering off;
}
``` 

~~This pull request also includes #49.~~