### PR TITLE
fixed security issue

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -436,7 +436,6 @@ impl Handler for MainHandler {
         // prevents an issue where the program's file scope could be escaped
         match fs_path.to_str() {
             Some(val) => {
-                println!("{}", val);
                 if val.contains("../") {
                     return Err(IronError::new(
                         io::Error::new(io::ErrorKind::PermissionDenied, "Path out of scope"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,6 +432,20 @@ impl Handler for MainHandler {
                 status::Forbidden,
             ));
         }
+        
+        // prevents an issue where the program's file scope could be escaped
+        match fs_path.to_str() {
+            Some(val) => {
+                println!("{}", val);
+                if val.contains("../") {
+                    return Err(IronError::new(
+                        io::Error::new(io::ErrorKind::PermissionDenied, "Path out of scope"),
+                        status::Forbidden,
+                    ));
+                }
+            }
+            _ => ()
+        }
 
         if self.upload && req.method == method::Post {
             if let Err((s, msg)) = self.save_files(req, &fs_path) {


### PR DESCRIPTION
Added a check to prevent a crafted payload from adding "../" to the filename in order to escape out of the scope of the program's files.

Exploit discovered by 5ut