### PR TITLE
Fixed security issue in upload system.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -490,15 +490,16 @@ impl MainHandler {
                                 let mut data = field.data.readable().unwrap();
                                 let headers = &field.headers;
                                 let mut target_path = path.clone();
-                                
-                                if headers.filename.clone().unwrap().contains("../") {
+
+                                target_path.push(headers.filename.clone().unwrap());
+
+                                if !target_path.starts_with(path) {
                                     return Err((
                                         status::Forbidden,
-                                        format!("Using filename to elevate folder scope is forbidden."),
+                                        format!("The file's save path was outside the fileserver's scope."),
                                     ));
                                 }
 
-                                target_path.push(headers.filename.clone().unwrap());
                                 if let Err(errno) = std::fs::File::create(target_path)
                                     .and_then(|mut file| io::copy(&mut data, &mut file))
                                 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -490,6 +490,13 @@ impl MainHandler {
                                 let mut data = field.data.readable().unwrap();
                                 let headers = &field.headers;
                                 let mut target_path = path.clone();
+                                
+                                if headers.filename.clone().unwrap().contains("../") {
+                                    return Err((
+                                        status::Forbidden,
+                                        format!("Using filename to elevate folder scope is forbidden."),
+                                    ));
+                                }
 
                                 target_path.push(headers.filename.clone().unwrap());
                                 if let Err(errno) = std::fs::File::create(target_path)


### PR DESCRIPTION
Allowing users to have the text "../" inside a filename allows them to escape the folder scope and essentially navigate anywhere they please if they can guess the filesystem's structure.