### PR TITLE
Define github actions workflows and publish binaries artifacts

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static", "-Zunstable-options"]
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,118 @@
+name: ci
+
+on:
+  pull_request: {}
+  push: {}
+  release:
+    types: [published]
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+          components: clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets --all-features -- -F warnings
+
+  test:
+    name: Unitest (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+          components: clippy
+      - uses: actions-rs/cargo@v1
+        env:
+          RUST_BACKTRACE: full
+          RUSTFLAGS: -F warnings
+        with:
+          command: test
+          args: --all --all-features
+      - name: "Ensure Cargo.lock is not modified"
+        run: git diff --exit-code Cargo.lock
+
+  build-release:
+    name: Build release Executable (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    env:
+      BINARY_EXTENSION: ${{ endsWith(matrix.target, '-msvc') && '.exe' || '' }}
+      PATH_BINARY: ${{ github.workspace }}/target/release/simple-http-server${{ endsWith(matrix.target, '-msvc') && '.exe' || '' }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+          components: clippy
+          target: ${{ matrix.target }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --bin simple-http-server --locked
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.target }}-simple-http-server${{ env.BINARY_EXTENSION }}
+          path: ${{ env.PATH_BINARY }}
+      - name: Evaluate shasum
+        run: echo -n $(shasum -ba 256 ${{ env.PATH_BINARY }} | cut -d " " -f 1) > ${{ env.PATH_BINARY }}.sha256
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.target }}-simple-http-server.sha256
+          path: ${{ env.PATH_BINARY }}.sha256
+
+      - name: '[Optional] Publish Artifact'
+        if: ${{ github.event_name == 'release' }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.PATH_BINARY }}
+          asset_name: ${{ matrix.target }}-simple-http-server${{ env.BINARY_EXTENSION }}
+          tag: ${{ github.ref }}
+          overwrite: true
+      - name: '[Optional] Publish Artifact (shasum)'
+        if: ${{ github.event_name == 'release' }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.PATH_BINARY }}.sha256
+          asset_name: ${{ matrix.target }}-simple-http-server${{ env.BINARY_EXTENSION }}.sha256
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ script:
 stages:
   - Check
   - Clippy
-  - Example
   - Test
 jobs:
   include:
@@ -21,10 +20,6 @@ jobs:
       name: Clippy
       script:
         - make clippy
-    - stage: Example
-      name: Example
-      script:
-        - make example
     - stage: Test
       name: Unitest
       script:

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,11 @@ fmt:
 	cargo fmt --all -- --check
 
 clippy:
-	RUSTFLAGS='-F warnings' cargo clippy --all --tests --all-features
+	cargo clippy --all --tests --all-features -- -F warnings
 
-example:
-	cargo build --examples
-
+test: export RUST_BACKTRACE := full
 test:
-	RUSTFLAGS='-F warnings' RUST_BACKTRACE=full cargo test --all --all-features
+	RUSTFLAGS='-F warnings'  cargo test --all --all-features
 
 ci: fmt clippy example test
 	git diff --exit-code Cargo.lock


### PR DESCRIPTION
Among the definition of github actions I've cleanup
* the build of examples as the project does not publish any example
* the usage of env variables in makefile
* the usage of `-Zunstable-options` in windows build (as no longer needed)

---

Tests will be performed on the main platforms: linux, macos, and windows.
On every workflow run the artifacts will be published as in [here](https://github.com/macisamuele/simple-http-server/actions/runs/630705109) (below the workflow graph representation you'll have link to downloaded the pre-built binaries associated to the commit).

Once a new release is published the artifacts will automatically be attached to the release as in https://github.com/macisamuele/simple-http-server/releases/tag/test-release 

## But why am I doing it?
I tend to use this tool very often and on machines where the rust compiler is not yet installed or that requires a significative time to have it running (Windows requires to download rust and a pretty extensive development toolkit).
Sometimes, I end up on bailing up and using `python -m http.server` as replacement ... and I wanted to change this.

So ensuring that binaries are available on the release it would simplify the general binary usage (also for platforms not usually used by developers :P) 