### PR TITLE
Strip symbols and add crate openssl to and allow the binary to run in distroless containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,14 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "openssl-src"
+version = "111.18.0+1.1.1n"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +483,7 @@ dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-src 111.18.0+1.1.1n (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -805,6 +814,7 @@ dependencies = [
  "mime_guess 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "open 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "path-dedot 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty-bytes 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1073,6 +1083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum open 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48"
 "checksum openssl 0.10.30 (registry+https://github.com/rust-lang/crates.io-index)" = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-src 111.18.0+1.1.1n (registry+https://github.com/rust-lang/crates.io-index)" = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
 "checksum openssl-sys 0.9.58 (registry+https://github.com/rust-lang/crates.io-index)" = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 "checksum path-dedot 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "45c58ab1edb03f77d0bb3f08e4a179dd43ce9bc8eab9867ec53a78285ea3039b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ filetime = "0.2.7"
 pretty-bytes = "0.2.2"
 rand = "0.8.3"
 url = "2.1.0"
-hyper-native-tls = {version = "0.3.0", optional=true}
+hyper-native-tls = { version = "0.3.0", optional = true }
 mime_guess = "2.0"
 open = "1"
-openssl = { version = "*", features = ["vendored"] }
+openssl = { version = "0.10", features = ["vendored"] }
 # Iron crates
 iron = "0.6.1"
 iron-cors = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ keywords = ["simple", "http", "server", "static", "file"]
 repository = "https://github.com/TheWaWaR/simple-http-server"
 edition = "2018"
 
-[profile.release]
-strip = "symbols"
-
 [dependencies]
 clap = "2.33.0"
 termcolor = "1.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ url = "2.1.0"
 hyper-native-tls = {version = "0.3.0", optional=true}
 mime_guess = "2.0"
 open = "1"
+openssl = { version = "*", features = ["vendored"] }
 # Iron crates
 iron = "0.6.1"
 iron-cors = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ keywords = ["simple", "http", "server", "static", "file"]
 repository = "https://github.com/TheWaWaR/simple-http-server"
 edition = "2018"
 
+[profile.release]
+strip = "symbols"
+
 [dependencies]
 clap = "2.33.0"
 termcolor = "1.0.5"


### PR DESCRIPTION
## Motivation

I was building a minimal distroless container image for this program, and I realized that the release binary's size can still be reduced significantly. Stripping the binary will cut a significant amount of size off the binary:

![image](https://user-images.githubusercontent.com/21986859/162853971-66d89ae1-c2f1-47c0-95cb-95058dc5d719.png)

The binary also doesn't run in Google's distroless `static` or `base` image since it cannot find libssl.

## Changes

- Added strip into the release profile to automatically strip the binary upon building the release.
- Added openssl as a build dependency so it will be integrated into the binary, allowing the binary to run on `static:nonroot`.

Here's an example Dockerfile I created for it: https://github.com/k4yt3x/simple-http-server/blob/master/Dockerfile

The final image is around 11 MiB in size, which is a decent size. I can open another PR for the Dockerfile if you're interested in maintaining it in your repo too.