### PR TITLE
feat: add headers useful to allow use of threads with webassembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ USAGE:
 
 FLAGS:
         --cors       Enable CORS via the "Access-Control-Allow-Origin" header
+        --coop       Add "Cross-Origin-Opener-Policy" HTTP header and set it to "same-origin"
+        --coep       Add "Cross-Origin-Embedder-Policy" HTTP header and set it to "require-corp"
     -h, --help       Prints help information
     -i, --index      Enable automatic render index page [index.html, index.htm]
         --nocache    Disable http cache

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ USAGE:
     simple-http-server [FLAGS] [OPTIONS] [--] [root]
 
 FLAGS:
-        --cors       Enable CORS via the "Access-Control-Allow-Origin" header
-        --coop       Add "Cross-Origin-Opener-Policy" HTTP header and set it to "same-origin"
         --coep       Add "Cross-Origin-Embedder-Policy" HTTP header and set it to "require-corp"
+        --coop       Add "Cross-Origin-Opener-Policy" HTTP header and set it to "same-origin"
+        --cors       Enable CORS via the "Access-Control-Allow-Origin" header
     -h, --help       Prints help information
     -i, --index      Enable automatic render index page [index.html, index.htm]
         --nocache    Disable http cache

--- a/src/main.rs
+++ b/src/main.rs
@@ -911,12 +911,16 @@ impl MainHandler {
                 resp.headers
                     .set_raw("content-type", vec![mime.to_string().into_bytes()]);
                 if self.coop {
-                    resp.headers
-                        .set_raw("Cross-Origin-Opener-Policy", vec!["same-origin".to_string().into_bytes()]);
+                    resp.headers.set_raw(
+                        "Cross-Origin-Opener-Policy",
+                        vec!["same-origin".to_string().into_bytes()],
+                    );
                 }
                 if self.coep {
-                    resp.headers
-                        .set_raw("Cross-Origin-Embedder-Policy", vec!["require-corp".to_string().into_bytes()]);
+                    resp.headers.set_raw(
+                        "Cross-Origin-Embedder-Policy",
+                        vec!["require-corp".to_string().into_bytes()],
+                    );
                 }
                 if self.range {
                     let mut range = req.headers.get::<Range>();

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,10 +104,10 @@ fn main() {
              .help("Enable CORS via the \"Access-Control-Allow-Origin\" header"))
         .arg(clap::Arg::with_name("coop")
              .long("coop")
-             .help("Enable \"Cross-Origin-Opener-Policy\": same-origin"))
+             .help("Add \"Cross-Origin-Opener-Policy\" HTTP header and set it to \"same-origin\""))
         .arg(clap::Arg::with_name("coep")
              .long("coep")
-             .help("Enable \"Cross-Origin-Embedder-Policy\": require-corp"))
+             .help("Add \"Cross-Origin-Embedder-Policy\" HTTP header and set it to \"require-corp\""))
         .arg(clap::Arg::with_name("certpass").
              long("certpass")
              .takes_value(true)


### PR DESCRIPTION
This adds two options to the server controlling two http headers which end up being required to let browser use threads with webassembly.

The use case here, is to have an html page with webassembly code in it, where the wasm uses threads, and allow firefox to run that code when opening the file via simple-http-server.

Maybe having only one option controlling both headers would make sense.