### PR TITLE
Update open lib to make it compile on Redox OS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,12 +593,13 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "open"
-version = "1.7.1"
+version = "5.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcea7a30d6b81a2423cc59c43554880feff7b57d12916f231a79f8d6d9470201"
+checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
 dependencies = [
+ "is-wsl",
+ "libc",
  "pathdiff",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hyper-native-tls = { version = "0.3.0", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 rustls = { version = "0.20", optional = true }
 mime_guess = "2.0"
-open = "1"
+open = "5"
 # Iron crates
 iron = "0.6.1"
 iron-cors = "0.8.0"


### PR DESCRIPTION
It was not working due to to old "open" crate. Redox OS reference is [here](https://gitlab.redox-os.org/redox-os/cookbook/-/blob/3808527251c55d7e7928d9569451aad0a376d170/recipes/wip/net/http/simple-http-server/recipe.toml).

```
error: open is not supported on this platform
  --> /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/open-1.7.1/src/lib.rs:84:1
   |
84 | compile_error!("open is not supported on this platform");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```


