### PR TITLE
fix: handle missing filename in file upload to prevent panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1085,6 +1085,3 @@ impl MainHandler {
         Ok(resp)
     }
 }
-
-
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -602,7 +602,7 @@ impl MainHandler {
                                     format!("Copy file failed: {errno}"),
                                 ));
                             } else {
-                                println!("  >> File saved: {}", raw_filename);
+                                println!("  >> File saved: {raw_filename}");
                             }
                         }
                         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,12 +583,11 @@ impl MainHandler {
                             let headers = &field.headers;
                             let mut target_path = path.to_owned();
 
-                            let raw_filename = match headers.filename.clone() {
-                                Some(name) => name,
-                                None => {
-                                    println!("[Warning]: Skipping field with no filename");
-                                    continue;
-                                }
+                            let raw_filename = if let Some(name) = headers.filename.clone() {
+                                name
+                            } else {
+                                println!("[Warning]: Skipping field with no filename");
+                                continue;
                             };
                             
                             let filename = if let Some(name) = Path::new(&raw_filename).file_name() {
@@ -1086,3 +1085,6 @@ impl MainHandler {
         Ok(resp)
     }
 }
+
+
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,17 +583,13 @@ impl MainHandler {
                             let headers = &field.headers;
                             let mut target_path = path.to_owned();
 
-                            let raw_filename = if let Some(name) = headers.filename.clone() {
-                                name
-                            } else {
+                            let Some(raw_filename) = headers.filename.clone() else {
                                 println!("[Warning]: Skipping field with no filename");
                                 continue;
                             };
                             
-                            let filename = if let Some(name) = Path::new(&raw_filename).file_name() {
-                                name
-                            } else {
-                                println!("[Warning]: Invalid filename: {}", raw_filename);
+                            let Some(filename) = Path::new(&raw_filename).file_name() else {
+                                println!("[Warning]: Invalid filename: {raw_filename}");
                                 continue;
                             };
                             

--- a/src/main.rs
+++ b/src/main.rs
@@ -587,12 +587,12 @@ impl MainHandler {
                                 println!("[Warning]: Skipping field with no filename");
                                 continue;
                             };
-                            
+
                             let Some(filename) = Path::new(&raw_filename).file_name() else {
                                 println!("[Warning]: Invalid filename: {raw_filename}");
                                 continue;
                             };
-                            
+
                             target_path.push(filename);
                             if let Err(errno) = std::fs::File::create(target_path)
                                 .and_then(|mut file| io::copy(&mut data, &mut file))

--- a/src/main.rs
+++ b/src/main.rs
@@ -591,12 +591,11 @@ impl MainHandler {
                                 }
                             };
                             
-                            let filename = match Path::new(&raw_filename).file_name() {
-                                Some(name) => name,
-                                None => {
-                                    println!("[Warning]: Invalid filename: {}", raw_filename);
-                                    continue;
-                                }
+                            let filename = if let Some(name) = Path::new(&raw_filename).file_name() {
+                                name
+                            } else {
+                                println!("[Warning]: Invalid filename: {}", raw_filename);
+                                continue;
                             };
                             
                             target_path.push(filename);


### PR DESCRIPTION
  Replace unwrap() calls with proper error handling when processing uploaded files.
  When no filename is provided, the server now logs a warning and continues
  processing instead of panicking.

  🤖 Generated with [Claude Code](https://claude.ai/code)

  Co-Authored-By: Claude <noreply@anthropic.com>
  
  [2025-08-02-upload.txt](https://github.com/user-attachments/files/21557640/2025-08-02-upload.txt)