### PR TITLE
Change version in docker, up rust

### DIFF
--- a/docker/Dockerfile.x86_64
+++ b/docker/Dockerfile.x86_64
@@ -2,7 +2,7 @@
 # LICENS: BSD 2-Clause "Simplified" License
 #    please see https://github.com/k4yt3x/simple-http-server/blob/master/LICENSE for more details
 
-FROM rust:1.61-alpine3.15 as builder
+FROM rust:1.89-alpine3.20 as builder
 # branch name or tag
 ARG BRANCH
 RUN apk add --no-cache --virtual .build-deps git make musl-dev openssl-dev perl pkgconfig \

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,9 +5,9 @@ LICENS: BSD 2-Clause "Simplified" License
 
 **NOTE**: `Dockerfile.aarch64` is not working for now.
 
-## Build the docker image with `v0.6.3`
+## Build the docker image with `v0.6.13`
 ```
-docker build --build-arg BRANCH=v0.6.3 -f Dockerfile.x86_64 . -t simple-http-server
+docker build --build-arg BRANCH=v0.6.13 -f Dockerfile.x86_64 . -t simple-http-server
 ```
 
 ## Run the docker image


### PR DESCRIPTION
Dockerfile contains `--features only-openssl` that are not present in v0.6.3 Also it seems that the Cargo.lock was generated by Rust version higher than the one that was being used in dockerfile, so I bumped rust version there as well.